### PR TITLE
Update route prefix condition for configuration requirement

### DIFF
--- a/packages/sdk/src/router.ts
+++ b/packages/sdk/src/router.ts
@@ -106,7 +106,7 @@ function getUrl(req: Request) {
 
 function getRoutePrefix(manifest: Manifest) {
   const hasConfig =
-    (manifest.config ?? []).length || manifest.behaviorHints?.configurable;
+    (manifest.config ?? []).length || manifest.behaviorHints?.configurationRequired;
   return hasConfig ? "{/:config}" : "";
 }
 


### PR DESCRIPTION
There is a case when the addon is configurable but it also support working with no config so it should say hasConfig=false it that case.

The case manifest has no config (length = 0), configurable = true, configurationRequired = false:
Expected behavior: hasConfig=false
Current behavior: hasConfig=true

Fix: check for configurationRequired instead of configurable. Because if manifest show configurationRequired then it must have a config to use. While configurable is just an indicator that the addon can be config or not.
Example my addon yastream work with no config (configurable = true, configurationRequired = false)